### PR TITLE
Remove internal cox dependency, support SSL

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,8 +1,8 @@
-name            'jantman-reviewboard'
+name            'thebaron-reviewboard'
 version         '1.0.1'
-summary         'Install and control reviewboard'
+summary         'Install and control reviewboard - forked from jantman'
 author          'Scott Wales, Jason Antman'
-project_page    'https://github.com/jantman/puppet-reviewboard'
+project_page    'https://github.com/thebaron/puppet-reviewboard'
 license         'Apache v2.0'
 
 description     <<END
@@ -14,9 +14,7 @@ dependency 'puppetlabs/stdlib', '>=2.2.1 <5.0.0'
 dependency 'puppetlabs/apache'
 dependency 'puppetlabs/concat', '>=1.1.1 <2.0.0'
 dependency 'puppetlabs/postgresql', '>= 4.0.0 <5.0.0'
-dependency 'coxmediagroup/virtualenv', '>=0.1.0 <2.0.0'
-dependency 'coxmediagroup/python', '>=0.0.6 <1.0.0'
-dependency 'coxmediagroup/yum', '>=0.2 <1.0.0'
+dependency 'stankevich/python', '>=1.11.0'
 # the following is optional, but there's no way to declare that
 dependency 'puppetlabs/mysql'
 dependency 'puppetlabs/nodejs', '>= 0.1.0, <1.0.0'

--- a/manifests/provider/web.pp
+++ b/manifests/provider/web.pp
@@ -26,6 +26,10 @@ define reviewboard::provider::web (
   $venv_python,
   $mod_wsgi_package_name = undef,
   $mod_wsgi_so_name      = undef,
+  $enable_ssl = false,
+  $enable_http = true,
+  $ssl_cert = undef,
+  $ssl_key = undef,
 ) {
 
   $site = $name
@@ -60,6 +64,10 @@ define reviewboard::provider::web (
       venv_python           => $venv_python,
       mod_wsgi_package_name => $mod_wsgi_package_name,
       mod_wsgi_so_name      => $mod_wsgi_so_name,
+      enable_ssl            => $enable_ssl,
+      enable_http           => $enable_http,
+      ssl_cert              => $ssl_cert,
+      ssl_key               => $ssl_key,
     }
 
     $realwebuser = $apache::user
@@ -79,7 +87,7 @@ define reviewboard::provider::web (
   }
 
   # Set web folder ownership
-  file {["${site}/data", "${site}/htdocs/media", "${site}/htdocs/media/ext", "${site}/logs"]:
+  file {["${site}/data", "${site}/htdocs/media", "${site}/htdocs/media/ext", "${site}/logs", "${site}/htdocs/static/ext"]:
     ensure  => directory,
     owner   => $realwebuser,
     notify  => $webservice,

--- a/manifests/provider/web/puppetlabsapache.pp
+++ b/manifests/provider/web/puppetlabsapache.pp
@@ -25,6 +25,10 @@ define reviewboard::provider::web::puppetlabsapache (
   $venv_python,
   $mod_wsgi_package_name = undef,
   $mod_wsgi_so_name      = undef,
+  $enable_ssl = false,
+  $enable_http = true,
+  $ssl_cert = undef,
+  $ssl_key = undef,
 ) {
 
   $site = $name
@@ -107,14 +111,31 @@ define reviewboard::provider::web::puppetlabsapache (
     },
   ]
 
-  apache::vhost {$vhost:
-    port                => 80,
-    docroot             => "${site}/htdocs",
-    error_documents     => $error_documents,
-    wsgi_script_aliases => $script_aliases,
-    custom_fragment     => 'WSGIPassAuthorization On',
-    directories         => $directories,
-    aliases             => $aliases,
+  if $enable_http {
+    apache::vhost {$vhost:
+      port                => 80,
+      docroot             => "${site}/htdocs",
+      error_documents     => $error_documents,
+      wsgi_script_aliases => $script_aliases,
+      custom_fragment     => 'WSGIPassAuthorization On',
+      directories         => $directories,
+      aliases             => $aliases,
+    }
+  }
+
+  if $enable_ssl {
+    apache::vhost { "$vhost-ssl":
+      port                => 443,
+      ssl                 => true,
+      docroot             => "${site}/htdocs",
+      error_documents     => $error_documents,
+      wsgi_script_aliases => $script_aliases,
+      custom_fragment     => 'WSGIPassAuthorization On',
+      directories         => $directories,
+      aliases             => $aliases,
+      ssl_cert            => $ssl_cert,
+      ssl_key             => $ssl_key,
+    }
   }
 
   # Propogate update events to the service

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -80,6 +80,22 @@
 #   and web root / htdocs.
 #   Default: $reviewboard::webuser
 #
+# [*enable_ssl*]
+#   Whether to enable SSL for the site.
+#   Default: false
+#
+# [*enable_http*]
+#   Whether to enable HTTP (non-ssl) for the site.
+#   Default: true
+#
+# [*ssl_cert*]
+#   Certificate file to use for SSL.
+#   Default: /etc/ssl/certs/$name.cert
+#
+# [*ssl_key*]
+#   Private key to use for SSL.
+#   Default:
+#
 #
 define reviewboard::site (
   $site       = $name,
@@ -96,6 +112,10 @@ define reviewboard::site (
   $cache      = 'memcached',
   $cacheinfo  = 'localhost:11211',
   $webuser    = $reviewboard::webuser,
+  $enable_ssl = false,
+  $enable_http= true,
+  $ssl_cert   = "/etc/ssl/certs/$name.cert",
+  $ssl_key    = "/etc/ssl/$name.key",
 ) {
   include reviewboard
 
@@ -146,6 +166,16 @@ define reviewboard::site (
     venv_path  => $reviewboard::venv_path,
   }
 
+  # make sure files exist if specified
+  if $enable_ssl {
+    if $ssl_cert {
+      validate_absolute_path($ssl_cert)
+    }
+    if $ssl_key {
+      validate_absolute_path($ssl_key)
+    }
+  }
+
   # Set up the web server
   reviewboard::provider::web {$site:
     vhost                 => $vhost,
@@ -157,6 +187,10 @@ define reviewboard::site (
     mod_wsgi_package_name => $reviewboard::mod_wsgi_package_name,
     mod_wsgi_so_name      => $reviewboard::mod_wsgi_so_name,
     require               => Reviewboard::Site::Install[$site],
+    enable_ssl            => $enable_ssl,
+    enable_http           => $enable_http,
+    ssl_cert              => $ssl_cert,
+    ssl_key               => $ssl_key,
   }
 
 }

--- a/spec/acceptance/reviewboard__site_spec.rb
+++ b/spec/acceptance/reviewboard__site_spec.rb
@@ -175,41 +175,27 @@ describe 'reviewboard::site' do
     context 'application tests' do
       describe 'test prerequisites' do
         test_prereq = <<-EOS.unindent
-          python_virtualenv {'/tmp/rbtest': 
+          python::virtualenv { '/tmp/rbtest':
             ensure     => present,
-            python     => $::python_latest_path,
           }
 
-          # make sure we have an acceptably new pip
-          python_package {'/tmp/rbtest,pip>=1.5.1':
-            ensure        => present,
-            python_prefix => '/tmp/rbtest',
-            requirements  => 'pip>=1.5.1',
-            options       => '--upgrade',
-            require       => Python_virtualenv['/tmp/rbtest'],
-          }
+          python::pip { '/tmp/rbtest,RBTools>=0.6.0' :
+            pkgname       => 'RBTools',
+            ensure        => '0.6.0',
+            virtualenv    => '/tmp/rbtest',
+           }
 
-          python_package {'/tmp/rbtest,RBTools>=0.6.0':
-            ensure        => present,
-            python_prefix => '/tmp/rbtest',
-            requirements  => 'RBTools>=0.6.0',
-            options       => ['--allow-unverified', 'RBTools'],
-            require       => Python_virtualenv['/tmp/rbtest'],
-          }
+          python::pip { '/tmp/rbtest,requests' :
+            pkgname       => 'requests',
+            ensure        => 'present',
+            virtualenv    => '/tmp/rbtest',
+           }
 
-          python_package {'/tmp/rbtest,requests':
-            ensure        => present,
-            python_prefix => '/tmp/rbtest',
-            requirements  => 'requests',
-            require       => Python_virtualenv['/tmp/rbtest'],
-          }
-
-          python_package {'/tmp/rbtest,python-memcached':
-            ensure        => present,
-            python_prefix => '/tmp/rbtest',
-            requirements  => 'python-memcached',
-            require       => Python_virtualenv['/tmp/rbtest'],
-          }
+          python::pip { '/tmp/rbtest,python-memcached' :
+            pkgname       => 'python-memcached',
+            ensure        => 'present',
+            virtualenv    => '/tmp/rbtest',
+           }
 
           class {'memcached':
             max_memory => '10%',
@@ -272,7 +258,7 @@ describe 'reviewboard::site' do
       end
       describe port(11211) do
         it { should be_listening }
-      end                 
+      end
       describe 'writes to memcache' do
         describe command('/tmp/rbtest/bin/python /tmp/rb_test.py -a memcached') do
           its(:exit_status) { should eq 0 }

--- a/spec/rb_test.py
+++ b/spec/rb_test.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO, format=FORMAT)
 logger = logging.getLogger(__name__)
 
 clone_path = '/tmp/puppet-reviewboard'
-github_url = 'https://github.com/jantman/puppet-reviewboard.git'
+github_url = 'https://github.com/thebaron/puppet-reviewboard.git'
 
 def get_api_root(user, password):
     client = RBClient('http://localhost/', username=user, password=password)


### PR DESCRIPTION
Jason,
Thanks for picking this mod up and keeping it alive. I noticed you have some deps that include Cox-specific python support. I changed it over to a community module that has similar function. I also added the ability to create an SSL vhost as well as disable HTTP/80 (since we don't want LDAP auth creds sent over cleartext). I also noticed that the directory static/ext needed to be created, so I added that to the list of dirs that are created/owned by apache. 

Moved to community python
Added SSL support
Added static directory creation